### PR TITLE
Added strg+c support

### DIFF
--- a/aids.go
+++ b/aids.go
@@ -25,10 +25,11 @@ func main() {
 	file := "/tmp/"
 	file += newLenChars(10, StdChars)
 	file += ".png"
+	var err error
 	if runtime.GOOS == "darwin" {
-		err := exec.Command("screencapture", "-i", file).Run()
+		err = exec.Command("screencapture", "-i", file).Run()
 	} else {
-		exec.Command("scrot", file, "-s").Run()
+		err = exec.Command("scrot", file, "-s").Run()
 	}
 	if err != nil {
 		notify.Push("aids", "aborting")

--- a/aids.go
+++ b/aids.go
@@ -24,7 +24,11 @@ func main() {
 	file := "/tmp/"
 	file += newLenChars(10, StdChars)
 	file += ".png"
-	exec.Command("scrot", file, "-s").Run()
+	err := exec.Command("scrot", file, "-s").Run()
+	if err != nil {
+		notify.Push("aids", "aborting.")
+		return
+	}
 	notify.Push("aids", "Uploading...")
 	url, err := Upload(file)
 	if err != nil {


### PR DESCRIPTION
When aborting the scrot command with strg+c aids would crash, because it tries to upload a non-existing file.
